### PR TITLE
Reproducible Benchmark: OptiKit vs Axo (local) for Overhead Analysis

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -35,6 +35,9 @@ jobs:
             sudo mkdir -p /sink
             sudo chown $USER:$USER /sink
             sudo chmod 777 /sink
+            sudo mkdir -p /axo
+            sudo chown $USER:$USER /axo
+            sudo chmod 777 /axo
             
       - name: Create network axo-net (external)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ htmlcov/
 *.lock
 dist/
 *.html
+**/reports
+.benchmarks/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ poetry install
 
 To install from the prebuilt package:
 ```bash
-poetry add axo==0.0.1a6 
+poetry add axo==0.0.3a0
 ```
 
 ⚠️ please use the newest version of Axo you can check it  https://github.com/muyal-research-group/axo

--- a/axo-endpoint.yml
+++ b/axo-endpoint.yml
@@ -1,6 +1,6 @@
 services:
     activex-endpoint-0:
-        image: nachocode/axo:endpoint-0.0.1a4
+        image: nachocode/axo:endpoint-0.0.2
         container_name: axo-endpoint-0
         ports:
                 - 16666:16666
@@ -11,7 +11,7 @@ services:
                 - AXO_LOGGER_PATH=/log
                 - AXO_LOGGER_WHEN=h
                 - AXO_LOGGER_INTERVAL=24
-                - AXO_ENDPOINT_IMAGE=nachocode/axo:endpoint-0.0.1a4
+                - AXO_ENDPOINT_IMAGE=nachocode/axo:endpoint-0.0.2
                 - AXO_PROTOCOL=tcp
                 - AXO_PUB_SUB_PORT=16666
                 - AXO_REQ_RES_PORT=16667
@@ -29,15 +29,15 @@ services:
                 - MICTLANX_MAX_WORKERS=4
                 - MICTLANX_ROUTERS=axo-storage-router-0:axo-storage-router-0:60666
         volumes:
-                - activex-endpoint-0:/log
-                - activex-endpoint-0-source:/source
-                - activex-endpoint-0-sink:/sink
+                - axo-endpoint-0:/log
+                - axo-endpoint-0-source:/source
+                - axo-endpoint-0-sink:/sink
         networks:
                 - axo-net
 volumes:
-    activex-endpoint-0:
-    activex-endpoint-0-sink:
-    activex-endpoint-0-source:
+    axo-endpoint-0:
+    axo-endpoint-0-sink:
+    axo-endpoint-0-source:
 networks:
     axo-net:
        external: true

--- a/axo-endpoint.yml
+++ b/axo-endpoint.yml
@@ -1,6 +1,6 @@
 services:
     activex-endpoint-0:
-        image: nachocode/axo:endpoint-0.0.2
+        image: nachocode/axo:endpoint-0.0.3a0
         container_name: axo-endpoint-0
         ports:
                 - 16666:16666

--- a/benchmarks/benchmark_algorithms.py
+++ b/benchmarks/benchmark_algorithms.py
@@ -208,7 +208,7 @@ async def suma_ponderada():
         print("Frente de Pareto generado con éxito:", res)
         assert res.is_ok
         solutions = res.unwrap()
-        sp.graficar_frente_pareto(solutions[0])
+        sp.plot(solutions[0])
         
 async def tabu_search():
     

--- a/optikit/algorithms/bees_algorithm.py
+++ b/optikit/algorithms/bees_algorithm.py
@@ -26,8 +26,7 @@ class BeesAlgorithm(Axo):
         neighbor = x + delta
         return max(self.lower, min(neighbor, self.upper))
     @axo_method
-    def bees(self, **kwargs):
-        os.makedirs("img", exist_ok=True)
+    def bees(self,show_plot:bool = False, **kwargs):
 
         population = [self._random_solution() for _ in range(self.n)]
         best_solution = min(population, key=self.f)
@@ -74,15 +73,16 @@ class BeesAlgorithm(Axo):
             history_elite.append(elite_sites)
             history_sites.append(selected_sites)
             history_scouts.append(scouts)
+            if show_plot: 
+                self._plot_iteration(it, elite_sites, selected_sites, scouts)
 
-            self._plot_iteration(it, elite_sites, selected_sites, scouts)
-
-        
-        self._plot_convergence(history_fx)
+        if show_plot:
+            self._plot_convergence(history_fx)
 
         return best_solution
 
     def _plot_iteration(self, iter_num, elites, sites, scouts, **kwargs):
+        os.makedirs("./img", exist_ok=True)
         x_curve = np.linspace(self.lower, self.upper, 400)
         y_curve = x_curve ** 2
 
@@ -101,6 +101,7 @@ class BeesAlgorithm(Axo):
         plt.close()
 
     def _plot_convergence(self, fx_history):
+        os.makedirs("./img", exist_ok=True)
         plt.figure(figsize=(8, 4))
         plt.plot(fx_history, marker='o', color='green')
         plt.title("Convergencia del Bees Algorithm")

--- a/optikit/algorithms/bellaman_ford.py
+++ b/optikit/algorithms/bellaman_ford.py
@@ -11,7 +11,7 @@ class BellmanFordAlgorithm(Axo):
         self.path, self.cost = nx.single_source_bellman_ford(self.graph, source=source)
         return self.path[target], self.cost[target]
 
-    def draw_path(self, path, algorithm_name="BellmanFord", **kwargs):
+    def draw_path(self, path, algorithm_name="BellmanFord",show_plot:bool = False, **kwargs):
         os.makedirs("img", exist_ok=True)
         pos = nx.spring_layout(self.graph, seed=42)
         plt.figure(figsize=(8, 5))
@@ -21,9 +21,9 @@ class BellmanFordAlgorithm(Axo):
 
         path_edges = list(zip(path, path[1:]))
         nx.draw_networkx_edges(self.graph, pos, edgelist=path_edges, edge_color='purple', width=3)
-
-        plt.title(f"Camino más corto con {algorithm_name}")
-        plt.axis('off')
-        plt.tight_layout()
-        plt.savefig(f"img/{algorithm_name.lower()}_camino.png")
-        plt.show()
+        if show_plot: 
+            plt.title(f"Camino más corto con {algorithm_name}")
+            plt.axis('off')
+            plt.tight_layout()
+            plt.savefig(f"img/{algorithm_name.lower()}_camino.png")
+            plt.show()

--- a/optikit/algorithms/cuckoo_search.py
+++ b/optikit/algorithms/cuckoo_search.py
@@ -29,8 +29,7 @@ class CuckooSearch(Axo):
         return max(self.lower, min(x, self.upper))
     
     @axo_method
-    def cuckoo(self, **kwargs):
-        os.makedirs("img", exist_ok=True)
+    def cuckoo(self,show_plots:bool= False, **kwargs):
 
         nests = [random.uniform(self.lower, self.upper) for _ in range(self.n)]
         fitness = [self.f(x) for x in nests]
@@ -59,11 +58,12 @@ class CuckooSearch(Axo):
                 best = current_best
 
             fx_history.append(self.f(best))
-
-        self.plot_convergence(fx_history)
+        if show_plots: 
+            self.plot_convergence(fx_history)
         return best
 
     def plot_convergence(self,fx_history, **kwargs):
+        os.makedirs("./img", exist_ok=True)
         plt.figure(figsize=(8, 4))
         plt.plot(fx_history, marker='o', color='navy')
         plt.title("Convergencia de Cuckoo Search")

--- a/optikit/algorithms/dijkstra.py
+++ b/optikit/algorithms/dijkstra.py
@@ -9,21 +9,19 @@ class DijkstraAlgorithm(Axo):
         self.graph = graph
 
     @axo_method
-    def dijkstra(self, source, target, **kwargs):
+    def dijkstra(self, source, target,show_plot:bool = False,**kwargs):
         # Devuelve el camino y el costo total desde source hasta target
         path, cost = nx.single_source_dijkstra(self.graph, source=source, target=target)
         return path, cost  # orden correcto: primero la lista del camino, luego el costo
 
-    def draw_path(self, path, algorithm_name="Dijkstra", **kwargs):
+    def plot(self, path, algorithm_name="Dijkstra", **kwargs):
         os.makedirs("img", exist_ok=True)
 
         pos = nx.spring_layout(self.graph, seed=42)
         plt.figure(figsize=(8, 5))
-
         nx.draw(self.graph, pos, with_labels=True, node_size=700, node_color='lightblue')
         edge_labels = nx.get_edge_attributes(self.graph, 'weight')
         nx.draw_networkx_edge_labels(self.graph, pos, edge_labels=edge_labels)
-
         path_edges = list(zip(path, path[1:]))
         nx.draw_networkx_edges(self.graph, pos, edgelist=path_edges, edge_color='crimson', width=3)
 

--- a/optikit/algorithms/local_search.py
+++ b/optikit/algorithms/local_search.py
@@ -1,4 +1,3 @@
-import random
 import matplotlib.pyplot as plt
 import os
 from axo import Axo, axo_method
@@ -22,7 +21,7 @@ class LocalSearch(Axo):
     def conditional(self, x, **kwargs):
         return abs(x) == 0  
     @axo_method
-    def local(self, **kwargs):
+    def local(self,show_plot:bool = False, **kwargs):
         s = self.x
         self.trayectoria.append(s)
         self.fx.append(self.obj_function(s))
@@ -52,6 +51,15 @@ class LocalSearch(Axo):
 
         print("Mejor solución encontrada:", s)
         return s
+    def plot(self):
+        plt.figure(figsize=(8, 4))
+        plt.plot(self.fx, marker='o', color='teal')
+        plt.title("Convergencia de Búsqueda Local en $f(x) = x^2$")
+        plt.xlabel("Iteración")
+        plt.ylabel("f(x)")
+        plt.grid()
+        plt.tight_layout()
+        plt.show()
 
 #if __name__ == "__main__":
 #    busqueda = LocalSearch(x=50)

--- a/optikit/algorithms/moead.py
+++ b/optikit/algorithms/moead.py
@@ -1,6 +1,7 @@
-from .individual import Individual
-from .utils import init_weights, get_neighbors, scalarizing_chebyshev
+from optikit.algorithms.individual import Individual
+from optikit.algorithms.utils import init_weights, get_neighbors, scalarizing_chebyshev
 import random
+import matplotlib.pyplot as plt
 from axo import Axo, axo_method
 
 class MOEAD(Axo):
@@ -22,7 +23,7 @@ class MOEAD(Axo):
         self.z = [min([ind.f[i] for ind in self.population]) for i in range(2)]
 
     @axo_method
-    def moea(self,**kwargs):
+    def moea(self,show_plot:bool = False,**kwargs):
         for gen in range(self.n_gen):
             for i in range(self.n_sub):
                 P = self.neighbors[i]
@@ -47,3 +48,13 @@ class MOEAD(Axo):
 
     def get_pareto_front(self, **kwargs):
         return [ind.f for ind in self.population]
+    def plot(self):
+        pareto = self.get_pareto_front()
+        f1_vals = [f[0] for f in pareto]
+        f2_vals = [f[1] for f in pareto]
+
+        plt.scatter(f1_vals, f2_vals ,s=10)
+        plt.xlabel("f1")
+        plt.ylabel("f2")
+        plt.title("Pareto Front")
+        plt.savefig("pareto_front.png", dpi=300)

--- a/optikit/algorithms/nsga2.py
+++ b/optikit/algorithms/nsga2.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ..problems.problem import Problems
+from optikit.problems.problem import Problems
 from axo import Axo, axo_method
 
 
@@ -92,7 +92,7 @@ class NSGA2(Axo):
 
     #ejecucin del algortimo 
     @axo_method
-    def nsga(self , **kwargs):
+    def nsga(self ,show_plot:bool = False, **kwargs):
         population = self.create_initial_population()
         objectives = self.evaluate(population)
         

--- a/optikit/algorithms/scatter_search.py
+++ b/optikit/algorithms/scatter_search.py
@@ -36,8 +36,7 @@ class ScatterSearch(Axo):
     def combine(self, s1, s2, *args, **kwargs):
         return (s1 + s2) / 2
     @axo_method
-    def scatter(self, *args, **kwargs):
-        os.makedirs("img", exist_ok=True)
+    def scatter(self,show_plot:bool= False, *args, **kwargs):
 
         pop = self.initialize_population()
         pop = self.improve_population(pop)
@@ -60,11 +59,13 @@ class ScatterSearch(Axo):
             best_fx = self.f(min(refset, key=self.f))
             fx_history.append(best_fx)
 
-        self._plot_convergence(fx_history)
+        if show_plot: 
+            self.plot(fx_history)
 
         return min(refset, key=self.f)
 
-    def _plot_convergence(self, fx_history, *args, **kwargs):
+    def plot(self, fx_history, *args, **kwargs):
+        os.makedirs("./img", exist_ok=True)
         plt.figure(figsize=(8, 4))
         plt.plot(fx_history, marker='o', color='purple')
         plt.title("Convergencia del Scatter Search")
@@ -74,18 +75,3 @@ class ScatterSearch(Axo):
         plt.tight_layout()
         plt.savefig("img/scatter_convergencia.png")
         plt.show()
-
-#if __name__ == "__main__":
-#    def objective(x):
-#        return x**2
-
-#    params = {
-#        "pop_size": 20,
-#        "refset_size": 5,
-#        "max_iter": 50
-#   }
-
-#    ss = ScatterSearch(objective, lower=-100, upper=100, params=params)
-#    mejor_x = ss.search()
-#    print("Mejor solución encontrada:", mejor_x)
-#    print("Valor de f(x):", objective(mejor_x))

--- a/optikit/algorithms/simulated_annealing.py
+++ b/optikit/algorithms/simulated_annealing.py
@@ -1,5 +1,5 @@
 from axo import Axo,axo_method
-
+import matplotlib.pyplot as plt
 class SimulatedAnnealing(Axo):
     def __init__(self, solucion_inicial, temperatura, temperatura_minima, factor_enfriamiento,*args,**kwargs):
         super().__init__(*args,**kwargs)
@@ -22,7 +22,7 @@ class SimulatedAnnealing(Axo):
     def simulated(self,**kwargs):
         import random
         import math
-        iteracion = 0
+        self.iteracion = 0
         while self.temperatura > self.temperatura_minima:
             nueva_solucion = self.generar_vecino(self.solucion_inicial)
             nuevo_coste = self.evaluar_coste(nueva_solucion)
@@ -35,31 +35,18 @@ class SimulatedAnnealing(Axo):
             self.historial_costes.append(self.coste_actual)
 
             self.temperatura *= self.factor_enfriamiento
-            iteracion += 1
+            self.iteracion += 1
 
-        return self.solucion_inicial, self.coste_actual, iteracion
+        return self.solucion_inicial, self.coste_actual, self.iteracion
 
+    def plot(self):
+        print(f"Solución encontrada: x = {self.solucion_inicial:.5f}")
+        print(f"Coste final: f(x) = {self.coste_actual:.5f}")
+        print(f"Iteraciones: {self.iteracion}")
 
-# import matplotlib.pyplot as plt
-
-
-# if __name__ == "__main__":
-#     sa = SimulatedAnnealing(
-#         solucion_inicial = random.uniform(-10, 10),
-#         temperatura_inicial = 100.0,
-#         temperatura_minima = 0.001,
-#         factor_enfriamiento = 0.95
-#     )
-
-#     solucion, coste, iteraciones = sa.enfriamiento()
-
-#     print(f"Solución encontrada: x = {solucion:.5f}")
-#     print(f"Coste final: f(x) = {coste:.5f}")
-#     print(f"Iteraciones: {iteraciones}")
-
-#     plt.plot(sa.historial_costes)
-#     plt.title("Evolución del coste en Simulated Annealing")
-#     plt.xlabel("Iteración")
-#     plt.ylabel("Coste f(x)")
-#     plt.grid(True)
-#     plt.show()
+        plt.plot(self.historial_costes) # Aqui hay pedo
+        plt.title("Evolución del coste en Simulated Annealing")
+        plt.xlabel("Iteración")
+        plt.ylabel("Coste f(x)")
+        plt.grid(True)
+        plt.show()

--- a/optikit/algorithms/suma_ponderada.py
+++ b/optikit/algorithms/suma_ponderada.py
@@ -1,8 +1,6 @@
 import numpy as np
 from scipy.optimize import minimize
 import matplotlib.pyplot as plt
-import time
-import csv
 from axo import Axo, axo_method
 
 
@@ -26,7 +24,7 @@ class SumaPonderada(Axo):
         return result.x, result.fun
 
     @axo_method
-    def suma(self, pasos=50, *args, **kwargs):
+    def suma(self, show_plot:bool = False,pasos=50, *args, **kwargs):
         solutions = []
         weights_list = []
 
@@ -40,7 +38,7 @@ class SumaPonderada(Axo):
 
         return np.array(solutions), weights_list
 
-    def graficar_frente_pareto(self, soluciones, *args, **kwargs):
+    def plot(self, soluciones, *args, **kwargs):
         plt.figure(figsize=(8, 6))
         plt.plot(soluciones[:, 0], soluciones[:, 1], 'bo-', label='Frente de Pareto (estimado)')
         plt.xlabel('f1(x)')

--- a/optikit/algorithms/tabu_search.py
+++ b/optikit/algorithms/tabu_search.py
@@ -11,7 +11,7 @@ class TabuSearch1D(Axo):
         self.max_iter = max_iter
         self.tabu_size = tabu_size
     @axo_method
-    def tabu(self, *args, **kwargs):
+    def tabu(self,show_plot:bool = False, *args, **kwargs):
         current = self.x0
         best = current
         tabu = []
@@ -29,11 +29,11 @@ class TabuSearch1D(Axo):
                 tabu.pop(0)
             current = candidate
             history.append(self.f(best))
-
-        self.plot_convergence(history)
+        if show_plot: 
+            self.plot(history)
         return best, self.f(best)
 
-    def plot_convergence(self, history, *args, **kwargs):
+    def plot(self, history, *args, **kwargs):
         os.makedirs("img", exist_ok=True)
         plt.figure(figsize=(8, 4))
         plt.plot(history, marker='o', color='darkorange')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = true
 python = ">=3.9,<4"
 networkx = "2.8.8"
 scipy = "1.13"
-axo="0.0.1a8"
+axo="0.0.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"
@@ -18,6 +18,9 @@ more-itertools = "^10.2.0"
 seaborn = "^0.13.2"
 pytest-asyncio = "^1.1.0"
 coverage = "^7.10.2"
+pytest-benchmark = "^5.1.0"
+pygal = "^3.0.5"
+pygaljs = "^1.0.2"
 
 [[tool.poetry.source]]
 name = "test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = true
 python = ">=3.9,<4"
 networkx = "2.8.8"
 scipy = "1.13"
-axo="0.0.2"
+axo="0.0.3a0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -1,0 +1,61 @@
+# 🧪 Benchmark Comparativo: Axo vs Baseline
+
+Este repositorio contiene pruebas de rendimiento automatizadas para comparar algoritmos implementados en Axo contra sus versiones baseline. Se utiliza `pytest-benchmark` para medir tiempos de ejecución y generar reportes reproducibles.
+
+---
+
+## 📁 Estructura de carpetas
+
+```bash
+tests/
+└── benchmark/
+    ├── test_baseline_simulated_annealing.py
+    ├── test_axo_simulated_annealing_local.py
+    ├── test_baseline_local_search.py
+    ├── test_axo_local_search.py
+    └── axo_vs_baseline.py  
+```
+## ⚙️ Preparación
+
+Antes de ejecutar los benchmarks, asegúrate de crear la carpeta de reportes:
+
+```bash
+mkdir -p tests/benchmark/reports/histograms
+```
+
+## 🚀 Ejecución de benchmarks
+- Simulated Annealing
+```bash
+pytest tests/benchmark/test_baseline_simulated_annealing.py \
+       tests/benchmark/test_axo_simulated_annealing_local.py \
+       --benchmark-only \
+       --benchmark-autosave \
+       --benchmark-compare \
+       --benchmark-histogram=tests/benchmark/reports/histograms/simulated_annealing.html \
+       --benchmark-json=tests/benchmark/reports/simulated_annealing.json
+```
+- Local Search
+```bash
+pytest tests/benchmark/test_baseline_local_search.py \
+       tests/benchmark/test_axo_local_search.py \
+       --benchmark-only \
+       --benchmark-autosave \
+       --benchmark-compare \
+       --benchmark-histogram=tests/benchmark/reports/histograms/local_search.html \
+       --benchmark-json=tests/benchmark/reports/local_search.json
+```
+## 📊 Comparación de Overhead
+
+Una vez generados los reportes .json, ejecuta el script comparativo para calcular el overhead entre Axo y Baseline:
+```bash
+poetry run python tests/benchmark/axo_vs_baseline.py
+```
+Este script genera una tabla en consola con los tiempos medios (µs) y el porcentaje de overhead por algoritmo.
+
+## 📌 Notas
+
+    Los histogramas generados en HTML permiten visualizar la distribución de tiempos por ejecución.
+
+    Los reportes .json incluyen metadatos del sistema, commit y estadísticas detalladas.
+
+    El script axo_vs_baseline.py puede extenderse para generar tablas Markdown o visualizaciones adicionales.

--- a/tests/benchmark/axo_vs_baseline.py
+++ b/tests/benchmark/axo_vs_baseline.py
@@ -1,0 +1,38 @@
+import json
+
+def extract_means(path):
+    with open(path, 'r') as f:
+        data = json.load(f)
+    baseline = axo = None
+    for b in data.get("benchmarks", []):
+        group = b.get("group", "")
+        mean = b.get("stats", {}).get("mean")
+        if group.startswith("baseline") and mean:
+            baseline = mean
+        elif group.startswith("axo") and mean:
+            axo = mean
+    return baseline, axo
+
+def calculate_overhead(baseline, axo):
+    if baseline is None or axo is None:
+        return None
+    return ((axo - baseline) / baseline) * 100
+
+def format_row(name, baseline, axo, overhead):
+    return f"| {name:<24} | {baseline:>10.2f} | {axo:>8.2f} | {overhead:>11.2f}% |"
+
+files = {
+    "Local Search": "tests/benchmark/reports/local_search.json",
+    "Simulated Annealing": "tests/benchmark/reports/simulated_annealing.json"
+}
+
+print("\n Overhead Axo y Baseline\n")
+print("| Algoritmo               | Baseline (µs) | Axo (µs) | Overhead (%) |")
+print("|-------------------------|---------------|----------|--------------|")
+
+for name, path in files.items():
+    baseline, axo = extract_means(path)
+    if baseline is not None and axo is not None:
+        print(format_row(name, baseline * 1e6, axo * 1e6, calculate_overhead(baseline, axo)))
+    else:
+        print(f"| {name:<24} |     error     |   error  |     error    |")

--- a/tests/benchmark/test_axo_local_search.py
+++ b/tests/benchmark/test_axo_local_search.py
@@ -1,0 +1,21 @@
+import pytest
+from optikit.algorithms.local_search import LocalSearch
+from axo.contextmanager import AxoContextManager
+from axo.endpoint.manager import DistributedEndpointManager
+import matplotlib.pyplot as plt
+
+    
+@pytest.mark.benchmark(group="axo_local_search")
+def test_axo_Local_search(benchmark):
+    with AxoContextManager.local():
+        ls = LocalSearch(x=50, axo_endpoint_id="axo-endpoint-0")
+        
+        def run_local():
+            ls.persistify()
+            return ls.local().unwrap_or(0)
+
+        result = benchmark.pedantic(run_local, iterations=10, rounds=100)
+
+    assert isinstance(result, (int, float))
+
+

--- a/tests/benchmark/test_axo_simulated_annealing_local.py
+++ b/tests/benchmark/test_axo_simulated_annealing_local.py
@@ -1,0 +1,29 @@
+import pytest
+import random
+from axo.contextmanager import AxoContextManager
+from axo.endpoint.manager import DistributedEndpointManager
+from optikit.algorithms.simulated_annealing import SimulatedAnnealing
+
+    
+    
+@pytest.mark.benchmark(group="axo_simulated")
+def test_axo_simulated_annealing(benchmark):
+    def run_sa():
+        with AxoContextManager.local():
+         sa = SimulatedAnnealing(
+            solucion_inicial=random.uniform(-10, 10),
+            temperatura=100.0,
+            temperatura_minima=0.0001,
+            factor_enfriamiento=0.95,
+            axo_endpoint_id = "axo-endpoint-0"
+        )
+        sa.persistify()
+        res = sa.simulated()
+        print(res)
+        assert res.is_ok
+        solucion, coste, iteraciones  = res.unwrap()
+       
+        return coste 
+    result = benchmark.pedantic(run_sa, iterations=10, rounds=100)
+    assert isinstance(result, float) 
+

--- a/tests/benchmark/test_axo_simulated_annealing_local.py
+++ b/tests/benchmark/test_axo_simulated_annealing_local.py
@@ -1,29 +1,56 @@
 import pytest
 import random
+import asyncio
 from axo.contextmanager import AxoContextManager
 from axo.endpoint.manager import DistributedEndpointManager
+from axo.storage.services import InMemoryStorageService
 from optikit.algorithms.simulated_annealing import SimulatedAnnealing
 
     
     
 @pytest.mark.benchmark(group="axo_simulated")
 def test_axo_simulated_annealing(benchmark):
-    def run_sa():
-        with AxoContextManager.local():
-         sa = SimulatedAnnealing(
-            solucion_inicial=random.uniform(-10, 10),
-            temperatura=100.0,
-            temperatura_minima=0.0001,
-            factor_enfriamiento=0.95,
-            axo_endpoint_id = "axo-endpoint-0"
-        )
-        sa.persistify()
-        res = sa.simulated()
-        print(res)
-        assert res.is_ok
-        solucion, coste, iteraciones  = res.unwrap()
+    async def run_sa():
+        with AxoContextManager.local() as rt:
+            sa = SimulatedAnnealing(
+                solucion_inicial=random.uniform(-10, 10),
+                temperatura=100.0,
+                temperatura_minima=0.0001,
+                factor_enfriamiento=0.95,
+                axo_endpoint_id = "axo-endpoint-0"
+            )
+            persistify_result = await sa.persistify()
+            assert persistify_result.is_ok
+            res =  sa.simulated()
+            assert res.is_ok
+            solucion, coste, iteraciones  = res.unwrap()
        
         return coste 
-    result = benchmark.pedantic(run_sa, iterations=10, rounds=100)
+    def runner():
+       return asyncio.run(run_sa())
+    result = benchmark.pedantic(runner, iterations=10, rounds=100)
     assert isinstance(result, float) 
 
+@pytest.mark.benchmark(group="axo_simulated_in_memory")
+def test_axo_simulated_annealing_in_memory(benchmark):
+    ss = InMemoryStorageService()
+    async def run_sa():
+        with AxoContextManager.local(storage_service=ss) as rt:
+            sa = SimulatedAnnealing(
+                solucion_inicial=random.uniform(-10, 10),
+                temperatura=100.0,
+                temperatura_minima=0.0001,
+                factor_enfriamiento=0.95,
+                axo_endpoint_id = "axo-endpoint-0"
+            )
+            persistify_result = await sa.persistify()
+            assert persistify_result.is_ok
+            res =  sa.simulated()
+            assert res.is_ok
+            solucion, coste, iteraciones  = res.unwrap()
+       
+        return coste 
+    def runner():
+       return asyncio.run(run_sa())
+    result = benchmark.pedantic(runner, iterations=10, rounds=100)
+    assert isinstance(result, float) 

--- a/tests/benchmark/test_baseline_local_search.py
+++ b/tests/benchmark/test_baseline_local_search.py
@@ -1,0 +1,56 @@
+import pytest
+
+
+class Local_Search():
+    def __init__(self, x):
+        self.x = x
+        self.trayectoria = [] 
+        self.fx = []     
+
+    def obj_function(self, x):
+        return x**2
+
+    def generate_neighbors(self, x ):
+        return [x - 1, x + 1]
+
+    def conditional(self, x, **kwargs):
+        return abs(x) == 0  
+    
+    def local(self):
+        s = self.x
+        self.trayectoria.append(s)
+        self.fx.append(self.obj_function(s))
+        print("Punto de partida:", s)
+        print("Valor objetivo inicial:", self.obj_function(s))
+        
+        while not self.conditional(s):
+            neighbors = self.generate_neighbors(s)
+            print("Vecinos:", neighbors)
+
+            best_neighbor = None
+            best_value = float('inf')
+
+            for neighbor in neighbors:
+                value = self.obj_function(neighbor)
+                if value < best_value:
+                    best_value = value
+                    best_neighbor = neighbor
+
+            if best_value < self.obj_function(s):
+                s = best_neighbor
+                self.trayectoria.append(s)
+                self.fx.append(self.obj_function(s))
+                
+            else:
+                break
+
+        print("Mejor solución encontrada:", s)
+        return s
+
+
+@pytest.mark.benchmark(group="baseline_local_search")
+def test_baseline_Local_search(benchmark):
+    ls:Local_Search = Local_Search(x=50)
+        
+    result = benchmark.pedantic(ls.local, iterations=10, rounds=100)
+    assert isinstance(result, int)  

--- a/tests/benchmark/test_baseline_simulated_annealing.py
+++ b/tests/benchmark/test_baseline_simulated_annealing.py
@@ -21,7 +21,7 @@ class Simulated_Annealing():
     def simulated(self):
         import random
         import math
-        iteracion = 0
+        self.iteracion = 0
         while self.temperatura > self.temperatura_minima:
             nueva_solucion = self.generar_vecino(self.solucion_inicial)
             nuevo_coste = self.evaluar_coste(nueva_solucion)
@@ -34,9 +34,9 @@ class Simulated_Annealing():
             self.historial_costes.append(self.coste_actual)
 
             self.temperatura *= self.factor_enfriamiento
-            iteracion += 1
+            self.iteracion += 1
 
-        return self.solucion_inicial, self.coste_actual, iteracion
+        return self.solucion_inicial, self.coste_actual, self.iteracion
 
 
 

--- a/tests/benchmark/test_baseline_simulated_annealing.py
+++ b/tests/benchmark/test_baseline_simulated_annealing.py
@@ -1,0 +1,57 @@
+import pytest
+import random
+
+class Simulated_Annealing():
+    def __init__(self, solucion_inicial, temperatura, temperatura_minima, factor_enfriamiento):
+        self.solucion_inicial = solucion_inicial
+        self.temperatura = temperatura
+        self.temperatura_minima = temperatura_minima
+        self.factor_enfriamiento = factor_enfriamiento
+        self.coste_actual = self.evaluar_coste(self.solucion_inicial)
+        self.historial_costes = []  
+        
+        
+    def generar_vecino(self, solucion_actual):
+        import random
+        return solucion_actual + random.uniform(-1, 1)
+
+    def evaluar_coste(self, solucion):
+        return solucion**2
+    
+    def simulated(self):
+        import random
+        import math
+        iteracion = 0
+        while self.temperatura > self.temperatura_minima:
+            nueva_solucion = self.generar_vecino(self.solucion_inicial)
+            nuevo_coste = self.evaluar_coste(nueva_solucion)
+            delta_e = nuevo_coste - self.coste_actual
+
+            if delta_e < 0 or random.random() < math.exp(-delta_e / self.temperatura):
+                self.solucion_inicial = nueva_solucion
+                self.coste_actual = nuevo_coste
+
+            self.historial_costes.append(self.coste_actual)
+
+            self.temperatura *= self.factor_enfriamiento
+            iteracion += 1
+
+        return self.solucion_inicial, self.coste_actual, iteracion
+
+
+
+@pytest.mark.benchmark(group="baseline_simulated")
+def test_baseline_simulated_annealing(benchmark):
+    def run_sa():
+        sa = Simulated_Annealing(
+            solucion_inicial=random.uniform(-10, 10),
+            temperatura=100.0,
+            temperatura_minima=0.0001,
+            factor_enfriamiento=0.95
+        )
+        solucion, coste, iteraciones = sa.simulated()
+        return coste 
+
+    result = benchmark.pedantic(run_sa, iterations=10, rounds=100)
+    assert isinstance(result, float)  
+    

--- a/tests/test_dijkstra.py
+++ b/tests/test_dijkstra.py
@@ -1,7 +1,6 @@
 import pytest
 from optikit.algorithms.dijkstra import DijkstraAlgorithm
 from axo.contextmanager import AxoContextManager
-import matplotlib.pyplot as plt
 import networkx as nx
 
 edges = [
@@ -26,5 +25,5 @@ async def test_local_Local_search():
         assert res.is_ok
         cost, path = res.unwrap()
         print("Dijkstra:", path, "Coste:", cost)
-        ad.draw_path(path)
+        # ad.plot(path)
        

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -29,12 +29,4 @@ async def test_local_Local_search():
         print("Mejor solución encontrada:", mejor_solucion)
         
         # Gráfica de convergencia
-        plt.figure(figsize=(8, 4))
-        plt.plot(ls.fx, marker='o', color='teal')
-        plt.title("Convergencia de Búsqueda Local en $f(x) = x^2$")
-        plt.xlabel("Iteración")
-        plt.ylabel("f(x)")
-        plt.grid()
-        plt.tight_layout()
-        plt.show()
 

--- a/tests/test_moea.py
+++ b/tests/test_moea.py
@@ -32,12 +32,4 @@ async def test_local_moea():
         result = moead.moea()
         assert result.is_ok
         pareto = moead.get_pareto_front()
-        f1_vals = [f[0] for f in pareto]
-        f2_vals = [f[1] for f in pareto]
-
-        plt.scatter(f1_vals, f2_vals ,s=10)
-        plt.xlabel("f1")
-        plt.ylabel("f2")
-        plt.title("Pareto Front")
-        plt.savefig("pareto_front.png", dpi=300)
         

--- a/tests/test_moea.py
+++ b/tests/test_moea.py
@@ -27,7 +27,7 @@ async def test_local_moea():
             "verbose": True,}
     
     with AxoContextManager.local() as dcm:
-        moead: MOEAD = MOEAD(fn_problem, n_var, bounds, n_gen=200, n_sub=100, T=20)
+        moead: MOEAD = MOEAD(fn_problem, n_var, bounds, n_gen=200, n_sub=100, T=20, axo_endpoint_id="axo-endpoint-0")
         _ = await moead.persistify()
         result = moead.moea()
         assert result.is_ok

--- a/tests/test_nsga2.py
+++ b/tests/test_nsga2.py
@@ -18,7 +18,7 @@ async def test_local_nsga2():
             "verbose": True,}
     
     with AxoContextManager.local() as dcm:
-        nsga2: NSGA2 = NSGA2(params)
+        nsga2: NSGA2 = NSGA2(params, axo_endpoint_id="axo-endpoint-0")
         _ = await nsga2.persistify()
         result = nsga2.nsga()
         assert result.is_ok

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -33,16 +33,6 @@ async def test_simulated_annealing(dem:DistributedEndpointManager):
         assert res.is_ok
         solucion, coste, iteraciones  = res.unwrap()
         
-        print(f"Solución encontrada: x = {solucion:.5f}")
-        print(f"Coste final: f(x) = {coste:.5f}")
-        print(f"Iteraciones: {iteraciones}")
-
-        plt.plot(sa.historial_costes) # Aqui hay pedo
-        plt.title("Evolución del coste en Simulated Annealing")
-        plt.xlabel("Iteración")
-        plt.ylabel("Coste f(x)")
-        plt.grid(True)
-        plt.show()
 
 
 @pytest.mark.asyncio

--- a/tests/test_suma_ponderada.py
+++ b/tests/test_suma_ponderada.py
@@ -14,6 +14,5 @@ async def test_suma_ponderada():
         print("Frente de Pareto generado con éxito:", res)
         assert res.is_ok
         solutions = res.unwrap()
-        sp.graficar_frente_pareto(solutions[0])
         
         


### PR DESCRIPTION
🧩 Issue relacionada
#6 – Benchmark: Comparison OptiKit (baseline) vs Axo (local) for overhead analysis

📌 Change Description
Reproducible benchmarks were implemented to compare the performance of optimization algorithms in two scenarios:

- Baseline: direct execution with OptiKit (without Axo).
- Axo Local: execution inside `AxoContextManager.local()` with `axo_endpoint_id="axo-endpoint-0"`.

The goal is to quantify the overhead introduced by Axo when running in local mode.

📦 Main changes

Added performance tests with `pytest-benchmark` under `tests/benchmark/` for:

- SimulatedAnnealing
- Local Search

Defined two execution paths per benchmark:

-  Baseline → direct execution without Axo.
-  Axo Local → execution with Axo.
- 
Automatic generation of results in .json and .html formats, along with visualizations using pygal and pygaljs.

Computation of overhead in terms of execution time and operations per second.

Technical documentation of the benchmarking workflow in a .md file.