### PR TITLE
[task] Add distributed execution support for active objects

### DIFF
--- a/axo-endpoint.yml
+++ b/axo-endpoint.yml
@@ -1,6 +1,6 @@
 services:
     activex-endpoint-0:
-        image: nachocode/axo:endpoint-0.0.3a0
+        image: nachocode/axo:endpoint-0.0.3a1
         container_name: axo-endpoint-0
         ports:
                 - 16666:16666

--- a/axo-endpoint.yml
+++ b/axo-endpoint.yml
@@ -11,7 +11,7 @@ services:
                 - AXO_LOGGER_PATH=/log
                 - AXO_LOGGER_WHEN=h
                 - AXO_LOGGER_INTERVAL=24
-                - AXO_ENDPOINT_IMAGE=nachocode/axo:endpoint-0.0.2
+                - AXO_ENDPOINT_IMAGE=nachocode/axo:endpoint-0.0.3a1
                 - AXO_PROTOCOL=tcp
                 - AXO_PUB_SUB_PORT=16666
                 - AXO_REQ_RES_PORT=16667

--- a/deploy_endpoint.sh
+++ b/deploy_endpoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "Stop axo-endpoint..."
+docker compose -f axo-endpoint.yml down
+echo "Deploying axo-endpoint ..."
+docker compose -f axo-endpoint.yml up -d  

--- a/deploy_storage.sh
+++ b/deploy_storage.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker network create -d bridge axo-net --subnet 11.0.0.0/25  || true
+
+echo "Stop storage service..."
+docker compose -f ./storage.yml -p axo-storage down
+echo "Deploying storage service..."
+docker compose -f ./storage.yml -p axo-storage up -d

--- a/optikit/algorithms/bellaman_ford.py
+++ b/optikit/algorithms/bellaman_ford.py
@@ -1,19 +1,35 @@
-import networkx as nx
-import matplotlib.pyplot as plt
 import os
 from axo import Axo,axo_method
 
+
 class BellmanFordAlgorithm(Axo):
+
     def __init__(self, graph,*args, **kwargs):
         self.graph = graph
+
+        
     @axo_method
-    def bellaman(self, source, target,**kwargs):
+    def run(self, source, target,**kwargs):
+        
+        import networkx as nx
+
         self.path, self.cost = nx.single_source_bellman_ford(self.graph, source=source)
+
         return self.path[target], self.cost[target]
 
-    def draw_path(self, path, algorithm_name="BellmanFord",show_plot:bool = False, **kwargs):
-        os.makedirs("img", exist_ok=True)
-        pos = nx.spring_layout(self.graph, seed=42)
+    @axo_method
+    async def plot(self, path, algorithm_name="BellmanFord",save_plot:bool = False, **kwargs):
+        import matplotlib.pyplot as plt
+        import networkx as nx
+        import io
+        from uuid import uuid4
+        from axo.storage.services import MictlanXStorageService
+
+        sink_bucket_id         = kwargs.get("sink_bucket_id","test")
+        sink_key               = kwargs.get("sink_key",uuid4().hex)
+        
+        storage:MictlanXStorageService = kwargs.get("storage")
+        pos                            = nx.spring_layout(self.graph, seed=42)
         plt.figure(figsize=(8, 5))
         nx.draw(self.graph, pos, with_labels=True, node_size=700, node_color='lightgreen')
         edge_labels = nx.get_edge_attributes(self.graph, 'weight')
@@ -21,9 +37,12 @@ class BellmanFordAlgorithm(Axo):
 
         path_edges = list(zip(path, path[1:]))
         nx.draw_networkx_edges(self.graph, pos, edgelist=path_edges, edge_color='purple', width=3)
-        if show_plot: 
+        if save_plot: 
             plt.title(f"Camino más corto con {algorithm_name}")
             plt.axis('off')
             plt.tight_layout()
-            plt.savefig(f"img/{algorithm_name.lower()}_camino.png")
-            plt.show()
+            buf = io.BytesIO()
+            plt.savefig(buf, format="png")   # you can also use "svg", "pdf", etc.
+            buf.seek(0)  # rewind to the beginning of the buffer
+            res = await storage.put(bucket_id=sink_bucket_id,key=sink_key, data=buf.getvalue())
+        return sink_bucket_id,sink_key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ package-mode = true
 python = ">=3.9,<4"
 networkx = "2.8.8"
 scipy = "1.13"
-axo="0.0.3a0"
+axo = "0.0.3a1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"

--- a/tests/test_bellaman_ford.py
+++ b/tests/test_bellaman_ford.py
@@ -1,8 +1,28 @@
 import pytest
+import pytest_asyncio
 from optikit.algorithms.bellaman_ford import BellmanFordAlgorithm
 from axo.contextmanager import AxoContextManager
 import matplotlib.pyplot as plt
 import networkx as nx
+from axo.storage.services import MictlanXStorageService
+from axo.endpoint.manager import DistributedEndpointManager
+from axo import Axo
+
+
+@pytest_asyncio.fixture(scope="session", autouse=True)
+# @pytest.mark.asyncio
+async def before_all_tests():
+    ss = MictlanXStorageService(
+        bucket_id   = "b1",
+        protocol    = "http",
+        routers_str = "mictlanx-router-0:localhost:60666"
+    )
+    bids = ["ao1bucket","ao2bucket"]
+    for bid in bids:
+        res = await ss.client.delete_bucket(bid)
+        print(f"BUCKET [{bid}] was clean")
+    yield
+
 
 edges = [
     ('A', 'B', 1),
@@ -17,15 +37,119 @@ G = nx.DiGraph()
 G.add_weighted_edges_from(edges)
 
 
+
+@pytest.fixture()
+def endpoint_manager()->DistributedEndpointManager:
+    dem = DistributedEndpointManager() 
+    dem.add_endpoint(
+        endpoint_id="axo-endpoint-0",
+        hostname="localhost",
+        protocol="tcp",
+        req_res_port=16667,
+        pubsub_port=16666
+    )
+    return dem
+
+@pytest.fixture()
+def storage_service()->MictlanXStorageService:
+    return MictlanXStorageService(
+        protocol="http",
+        routers_str="mictlanx-router-0:localhost:60666"
+    )
+
 @pytest.mark.asyncio
 async def test_local_Local_search():
+
     with AxoContextManager.local() as dcm:
         bf:BellmanFordAlgorithm = BellmanFordAlgorithm(G, axo_endpoint_id="axo-endpoint-0")
         _ = await bf.persistify()
-        res = bf.bellaman('A', 'Z')
+        res = bf.run('A', 'Z')
         assert res.is_ok
         print(res)
-        # cost, path = res.unwrap()
-        # print("Bellaman ford:", path, "Coste:", cost)
-        # bf.draw_path(path)
        
+@pytest.mark.asyncio
+async def test_distributed_local_search(endpoint_manager:DistributedEndpointManager,storage_service:MictlanXStorageService):
+
+    with AxoContextManager.distributed(endpoint_manager=endpoint_manager, storage_service=storage_service) as dcm:
+
+        axo_endpoint_id         = "axo-endpoint-0"
+        sink_bucket_id          = "ao1_sink_bucket"
+        sink_key                = "ao1_sink_key"
+
+        axo_key                 = "ao1"
+        axo_bucket_id           = "ao1bucket"
+
+        bf:BellmanFordAlgorithm = BellmanFordAlgorithm(
+            graph           = G, 
+            axo_key         = axo_key,
+            axo_bucket_id   = axo_bucket_id,
+            axo_endpoint_id = axo_endpoint_id
+        )
+        
+        bf.append_dependency("networkx==3.2.1")
+
+        bf.append_dependency("matplotlib==3.9.2")
+        
+        # Guardar objeto
+        persistify_result = await bf.persistify()
+        
+        assert persistify_result.is_ok
+
+        #  Ejecutar objeto
+        res = bf.run('A', 'Z')
+        assert res.is_ok
+
+        _,path   = res.unwrap()
+        # Ejecutar otro metodo del objeto
+        res_plot = bf.plot(
+            path,
+            sink_bucket_id = sink_bucket_id,
+            sink_key       = sink_key,
+            save_plot      = True
+        )
+        
+        assert res_plot.is_ok
+
+@pytest.mark.asyncio
+async def test_distributed_local_search_zk(endpoint_manager:DistributedEndpointManager,storage_service:MictlanXStorageService):
+
+    with AxoContextManager.distributed(endpoint_manager=endpoint_manager, storage_service=storage_service) as dcm:
+
+        axo_endpoint_id         = "axo-endpoint-0"
+        sink_bucket_id          = "ao2_sink_bucket"
+        sink_key                = "ao2_sink_key"
+        axo_key                 = "ao2"
+        axo_bucket_id           = "ao2bucket"
+        bf:BellmanFordAlgorithm = BellmanFordAlgorithm(
+            graph           = G, 
+            axo_key         = axo_key,
+            axo_bucket_id   = axo_bucket_id,
+            axo_endpoint_id = axo_endpoint_id
+        )
+        
+        bf.append_dependency("networkx==3.2.1")
+
+        bf.append_dependency("matplotlib==3.9.2")
+        
+        # Guardar objeto
+        persistify_result = await bf.persistify()
+        
+        assert persistify_result.is_ok
+    
+
+        
+        ao_res = await Axo.get_by_key(bucket_id=axo_bucket_id,key=axo_key)
+        assert ao_res.is_ok
+        bf = ao_res.unwrap()
+        res = bf.run('A', 'Z')
+        assert res.is_ok
+        _,path   = res.unwrap()
+        # Ejecutar otro metodo del objeto
+        res_plot = bf.plot(
+            path,
+            sink_bucket_id = sink_bucket_id,
+            sink_key       = sink_key,
+            save_plot      = True
+        )
+        
+        assert res_plot.is_ok


### PR DESCRIPTION
This PR introduces initial support for running optimization objects (`BellmanFordAlgorithm`) in a distributed context using `AxoContextManager.distributed`.
It demonstrates:

- Persisting objects with `persistify()`

- Restoring objects with `Axo.get_by_key()`

- Executing methods (run, plot) on both original and restored objects

Includes example tests:

- `test_distributed_local_search`

- `test_distributed_local_search_zk`